### PR TITLE
Feature/#50

### DIFF
--- a/core/data/src/main/java/com/tgyuu/data/repository/repository/chatting/MentoringChattingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/repository/chatting/MentoringChattingRepositoryImpl.kt
@@ -41,7 +41,7 @@ class MentoringChattingRepositoryImpl @Inject constructor(
     )
 
     override suspend fun getAllMessage(roomId: String): Flow<MentoringMessage> =
-        chattingDataSource.getAllMessage(roomId).map {
+        chattingDataSource.subscribeMessages(roomId).map {
             MentoringMessage(
                 roomId = it.roomId,
                 userId = it.userId,

--- a/core/data/src/main/java/com/tgyuu/data/repository/repository/chatting/MentoringChattingRepositoryImpl.kt
+++ b/core/data/src/main/java/com/tgyuu/data/repository/repository/chatting/MentoringChattingRepositoryImpl.kt
@@ -40,7 +40,7 @@ class MentoringChattingRepositoryImpl @Inject constructor(
         ),
     )
 
-    override suspend fun getAllMessage(roomId: String): Flow<MentoringMessage> =
+    override suspend fun subscribeMessages(roomId: String): Flow<MentoringMessage> =
         chattingDataSource.subscribeMessages(roomId).map {
             MentoringMessage(
                 roomId = it.roomId,
@@ -49,6 +49,22 @@ class MentoringChattingRepositoryImpl @Inject constructor(
                 createdAt = it.createdAt,
                 isChecked = it.isChecked,
             )
+        }
+
+    override suspend fun getPreviousMessages(
+        roomId: String,
+        lastTime: String,
+    ): Result<List<MentoringMessage>> =
+        chattingDataSource.getPreviousMessages(roomId, lastTime).mapCatching {
+            it.map {
+                MentoringMessage(
+                    roomId = it.roomId,
+                    userId = it.userId,
+                    content = it.content,
+                    createdAt = it.createdAt,
+                    isChecked = it.isChecked,
+                )
+            }
         }
 
     override suspend fun getMentorChattingRoom(userId: String): Result<List<JoinChat>> =

--- a/core/domain/src/main/java/com/tgyuu/domain/repository/chatting/MentoringChattingRepository.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/repository/chatting/MentoringChattingRepository.kt
@@ -12,7 +12,12 @@ interface MentoringChattingRepository {
         createdAt: String,
     ): Result<Unit>
 
-    suspend fun getAllMessage(roomId: String): Flow<MentoringMessage>
+    suspend fun subscribeMessages(roomId: String): Flow<MentoringMessage>
+
+    suspend fun getPreviousMessages(
+        roomId: String,
+        lastTime: String,
+    ): Result<List<MentoringMessage>>
 
     suspend fun getMentorChattingRoom(userId: String): Result<List<JoinChat>>
 

--- a/core/domain/src/main/java/com/tgyuu/domain/usecase/chatting/GetPreviousMentoringMessagesUseCase.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/usecase/chatting/GetPreviousMentoringMessagesUseCase.kt
@@ -1,0 +1,13 @@
+package com.tgyuu.domain.usecase.chatting
+
+import com.tgyuu.domain.repository.chatting.MentoringChattingRepository
+import com.tgyuu.model.chatting.MentoringMessage
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetPreviousMentoringMessagesUseCase @Inject constructor(
+    private val mentoringChattingRepository: MentoringChattingRepository,
+) {
+    suspend operator fun invoke(roomId: String, lastTime: String): Result<List<MentoringMessage>> =
+        mentoringChattingRepository.getPreviousMessages(roomId, lastTime)
+}

--- a/core/domain/src/main/java/com/tgyuu/domain/usecase/chatting/SubscribeMentoringMessagesUseCase.kt
+++ b/core/domain/src/main/java/com/tgyuu/domain/usecase/chatting/SubscribeMentoringMessagesUseCase.kt
@@ -5,9 +5,9 @@ import com.tgyuu.model.chatting.MentoringMessage
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetMentoringChattingMessagesUseCase @Inject constructor(
+class SubscribeMentoringMessagesUseCase @Inject constructor(
     private val mentoringChattingRepository: MentoringChattingRepository,
 ) {
     suspend operator fun invoke(roomId: String): Flow<MentoringMessage> =
-        mentoringChattingRepository.getAllMessage(roomId)
+        mentoringChattingRepository.subscribeMessages(roomId)
 }

--- a/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSource.kt
@@ -1,6 +1,5 @@
 package com.tgyuu.network.source.chatting
 
-import com.google.firebase.Timestamp
 import com.tgyuu.network.model.chatting.ai.AiChatRequest
 import com.tgyuu.network.model.chatting.ai.AiChatResponse
 import com.tgyuu.network.model.chatting.mentoring.JoinChatRequest
@@ -19,7 +18,10 @@ interface ChattingDataSource {
 
     suspend fun subscribeMessages(roomId: String): Flow<MentoringChatResponse>
 
-    suspend fun getPreviousMessages(roomId: String, lastTime: String)
+    suspend fun getPreviousMessages(
+        roomId: String,
+        lastTime: String,
+    ): Result<List<MentoringChatResponse>>
 
     suspend fun getMentorChattingRoom(userId: String): Result<List<JoinChatResponse>>
 

--- a/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSource.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSource.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.network.source.chatting
 
+import com.google.firebase.Timestamp
 import com.tgyuu.network.model.chatting.ai.AiChatRequest
 import com.tgyuu.network.model.chatting.ai.AiChatResponse
 import com.tgyuu.network.model.chatting.mentoring.JoinChatRequest
@@ -16,7 +17,9 @@ interface ChattingDataSource {
         joinChatRequest: JoinChatRequest,
     ): Result<Unit>
 
-    suspend fun getAllMessage(roomId: String): Flow<MentoringChatResponse>
+    suspend fun subscribeMessages(roomId: String): Flow<MentoringChatResponse>
+
+    suspend fun getPreviousMessages(roomId: String, lastTime: String)
 
     suspend fun getMentorChattingRoom(userId: String): Result<List<JoinChatResponse>>
 

--- a/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
@@ -54,6 +54,8 @@ class ChattingDataSourceImpl @Inject constructor(
                 .whereGreaterThan("createdAt", generateNowDateTime().toISOLocalDateTimeString())
                 .orderBy("createdAt", Query.Direction.ASCENDING)
                 .addSnapshotListener { value, error ->
+                    Log.d("test", "subscribeMessage 작동")
+
                     if (error != null) {
                         logAnalytics(error.stackTraceToString())
                         return@addSnapshotListener
@@ -83,9 +85,13 @@ class ChattingDataSourceImpl @Inject constructor(
         lastTime: String,
     ): Result<List<MentoringChatResponse>> =
         runCatching {
+            Log.d("test", "PreviousMessage 호출")
+
             val documents = firebaseFirestore.collection(MESSAGE_COLLECTION)
                 .whereEqualTo("roomId", roomId)
+                .whereLessThan("createdAt", lastTime)
                 .orderBy("createdAt", Query.Direction.DESCENDING)
+                .limit(30)
                 .get()
                 .await()
 

--- a/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
@@ -15,7 +15,9 @@ import com.tgyuu.network.model.chatting.mentoring.JoinChatResponse
 import com.tgyuu.network.model.chatting.mentoring.MentoringChatRequest
 import com.tgyuu.network.model.chatting.mentoring.MentoringChatResponse
 import com.tgyuu.network.util.await
+import com.tgyuu.network.util.generateNowDateTime
 import com.tgyuu.network.util.logAnalytics
+import com.tgyuu.network.util.toISOLocalDateTimeString
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -44,9 +46,10 @@ class ChattingDataSourceImpl @Inject constructor(
                 .await()
         }
 
-    override suspend fun getAllMessage(roomId: String): Flow<MentoringChatResponse> = callbackFlow {
+    override suspend fun subscribeMessages(roomId: String): Flow<MentoringChatResponse> = callbackFlow {
         val listenerRegistration = firebaseFirestore.collection(MESSAGE_COLLECTION)
             .whereEqualTo("roomId", roomId)
+            .whereGreaterThan("createdAt", generateNowDateTime().toISOLocalDateTimeString())
             .orderBy("createdAt", Query.Direction.ASCENDING)
             .addSnapshotListener { value, error ->
                 if (error != null) {
@@ -71,6 +74,10 @@ class ChattingDataSourceImpl @Inject constructor(
             }
 
         awaitClose { listenerRegistration.remove() }
+    }
+
+    override suspend fun getPreviousMessages(roomId: String, lastTime: String) {
+        TODO("Not yet implemented")
     }
 
     override suspend fun getMentorChattingRoom(userId: String): Result<List<JoinChatResponse>> =

--- a/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
+++ b/core/network/src/main/java/com/tgyuu/network/source/chatting/ChattingDataSourceImpl.kt
@@ -91,7 +91,7 @@ class ChattingDataSourceImpl @Inject constructor(
                 .whereEqualTo("roomId", roomId)
                 .whereLessThan("createdAt", lastTime)
                 .orderBy("createdAt", Query.Direction.DESCENDING)
-                .limit(30)
+                .limit(PAGING_SIZE)
                 .get()
                 .await()
 
@@ -125,4 +125,9 @@ class ChattingDataSourceImpl @Inject constructor(
                         ?: throw IllegalArgumentException("Invalid mentee info")
                 }
         }
+
+
+    companion object{
+        private const val PAGING_SIZE = 30L
+    }
 }

--- a/feature/chatting-ai/src/main/java/com/tgyuu/chatting/ai/AiChattingScreen.kt
+++ b/feature/chatting-ai/src/main/java/com/tgyuu/chatting/ai/AiChattingScreen.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.chatting.ai
 
+import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -100,14 +101,12 @@ internal fun AiChattingScreen(
         ),
     )
 
-    LaunchedEffect(chatLog) {
-        if (previousChatSize != chatLog.size) {
-            coroutineScope.launch {
-                listState.animateScrollToItem(chatLog.size - 1)
-            }
-
-            previousChatSize = chatLog.size
+    LaunchedEffect(previousChatSize != chatLog.size) {
+        coroutineScope.launch {
+            listState.animateScrollToItem(chatLog.size)
         }
+
+        previousChatSize = chatLog.size
     }
 
     Scaffold(contentWindowInsets = WindowInsets(0.dp)) { paddingValues ->

--- a/feature/chatting-mentoring/src/main/java/com/tgyuu/feature/chatting/mentoring/MentoringChattingScreen.kt
+++ b/feature/chatting-mentoring/src/main/java/com/tgyuu/feature/chatting/mentoring/MentoringChattingScreen.kt
@@ -1,5 +1,6 @@
 package com.tgyuu.feature.chatting.mentoring
 
+import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -83,8 +84,11 @@ internal fun MentoringChattingRoute(
     val userInformation by viewModel.userInformation.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) {
-        viewModel.roomId.value = roomId
-        viewModel.getMessages()
+        viewModel.apply {
+            this.roomId.value = roomId
+            getPreviousMessages()
+            subscribeMessages()
+        }
     }
 
     MentoringChattingScreen(
@@ -130,14 +134,13 @@ internal fun MentoringChattingScreen(
     )
     var previousChatSize by remember { mutableStateOf(0) }
 
-    LaunchedEffect(chatLog) {
-        if (previousChatSize != chatLog.size) {
-            coroutineScope.launch {
-                listState.animateScrollToItem(chatLog.size - 1)
-            }
-
-            previousChatSize = chatLog.size
+    LaunchedEffect(previousChatSize != chatLog.size) {
+        Log.d("test", "스크롤 이벤트 호출")
+        coroutineScope.launch {
+            listState.animateScrollToItem(chatLog.size)
         }
+
+        previousChatSize = chatLog.size
     }
 
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {

--- a/feature/chatting-mentoring/src/main/java/com/tgyuu/feature/chatting/mentoring/MentoringChattingViewModel.kt
+++ b/feature/chatting-mentoring/src/main/java/com/tgyuu/feature/chatting/mentoring/MentoringChattingViewModel.kt
@@ -92,20 +92,19 @@ class MentoringChattingViewModel @Inject constructor(
     }
 
     fun getPreviousMessages() {
-        if (!isLoading.get()) {
-            isLoading.getAndSet(true)
-            viewModelScope.launch {
+        viewModelScope.launch {
+            if (!isLoading.get()) {
+                isLoading.getAndSet(true)
                 getPreviousMentoringMessagesUseCase(
                     _roomId.value,
                     _pagingTimeStamp.value,
                 )
                     .onSuccess {
-                        if (it.size < 30) {
+                        if (it.size < PAGING_SIZE) {
                             _isFirstPage.value = true
                         }
 
                         chatLog.addAll(0, it)
-                        Log.d("test", "chatLog : ${chatLog.toList()}")
 
                         if (it.size != 0) {
                             _pagingTimeStamp.value = chatLog[0].createdAt
@@ -121,4 +120,9 @@ class MentoringChattingViewModel @Inject constructor(
     fun subscribeMessages() = viewModelScope.launch {
         subscribeMentoringMessagesUseCase(_roomId.value).collect { chatLog.add(it) }
     }
+
+    companion object{
+        private const val PAGING_SIZE = 30
+    }
+
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개
- closed #50 

## 2. 🔥변경된 점
- **채팅방 들어올 때 이전 메시지 받아오도록 변경**
- **이후 메세지들을 Flow로 구독하도록 변경**
- **페이징 적용**

## 3. 📸 스크린샷(선택)

## 4. 💡알게된 혹은 궁금한 사항들

## 페이징을 적용해서 함수를 호출하려고 하는데, 생각대로 안되는데요 ?

```kotlin
var previousChatTime by remember { mutableStateOf("") }

    LaunchedEffect(chatLog.size) {
        if (previousChatTime != (chatLog.lastOrNull()?.createdAt ?: "")) {
            coroutineScope.launch {
                listState.scrollToItem(chatLog.size)
                previousChatTime = chatLog.last().createdAt
            }
        }
    }

    LaunchedEffect(listState.firstVisibleItemIndex) {
        if (listState.firstVisibleItemIndex <= 3 && !isFirstPage) {
            getPreviousMessages()
        }
    }
```

내가 **보고있는 채팅창**의 `LazyColumn` 의 `Item` 인덱스가 `3`이하일 경우,

새롭게 이전 채팅 데이터를 호출해서 `30개` 정도를 호출하려고 했는데.

근데, 이걸 계속 호출해버리니까 똑같은 채팅 데이터를 여러 번 받아버리더라고요..

<br><br><br><br><br><br>

그래서 일단 아래 처럼 `atomicBoolean`을 써서 중복 호출을 막아둬서 해결하긴 했는데,,,

조금 더 좋은 경우가 있는 지는 계속해서 탐색해봐야 알 것 같따.

```kotlin
    fun getPreviousMessages() = viewModelScope.launch {
        if (!isLoading.get()) {
            isLoading.getAndSet(true)
            getPreviousMentoringMessagesUseCase(
                _roomId.value,
                _pagingTimeStamp.value,
            )
                .onSuccess {
                    if (it.size < PAGING_SIZE) {
                        _isFirstPage.value = true
                    }

                    chatLog.addAll(0, it)

                    if (it.size != 0) {
                        _pagingTimeStamp.value = chatLog[0].createdAt
                    }
                }
                .onFailure { Log.d("test", "onFailure : " + it.toString()) }
                .also { isLoading.getAndSet(false) }

        }
    }
```

[기똥찬 firestore 채팅방 레퍼런스](https://nosorae.tistory.com/entry/2%EC%9B%94-26%EC%9D%BC)
